### PR TITLE
refactor: Handle garbage token

### DIFF
--- a/src/azure-token-validation/azure-token-validation.service.spec.ts
+++ b/src/azure-token-validation/azure-token-validation.service.spec.ts
@@ -74,6 +74,13 @@ describe('AzureTokenValidationService', () => {
       const response = await service.isTokenValid(testToken);
       expect(response).toBeFalsy();
       expect(getTokensMock).toHaveBeenCalledTimes(1);
+      expect(verifyMock).toHaveBeenCalledTimes(1);
+    });
+    it('should return false on garbage token', async () => {
+      const response = await service.isTokenValid('fdae');
+      expect(response).toBeFalsy();
+      expect(getTokensMock).toHaveBeenCalledTimes(1);
+      expect(verifyMock).toHaveBeenCalledTimes(0);
     });
   });
   describe('getAzureUserFromToken()', () => {

--- a/src/azure-token-validation/azure-token-validation.service.ts
+++ b/src/azure-token-validation/azure-token-validation.service.ts
@@ -22,11 +22,19 @@ export class AzureTokenValidationService {
     accessToken: string,
   ): Promise<AzureAdUser> {
     const keys = (await this.getAzureKeys()).keys;
-    const tokenHeader = this.getTokenHeader(accessToken);
+    let tokenHeader: TokenHeader;
+    try {
+      tokenHeader = this.getTokenHeader(accessToken);
+    } catch (err) {
+      this.logger.error(
+        `Unable to extract Header from AccessToken: ${accessToken} for error ${err.toString()}`,
+      );
+      return null;
+    }
     const key = keys.find(x => x.kid === tokenHeader.kid);
     if (!key) {
       this.logger.error(
-        `Unable to find Public Signing key matching kid(KeyId): ${key.kid}`,
+        `Unable to find Public Signing key matching Token Header kid(KeyId): ${tokenHeader.kid}`,
       );
       return null;
     }


### PR DESCRIPTION
Handle a garbage token where the header is not parseable.